### PR TITLE
Remove is_admin() check from constructor to allow plugin to be used with...

### DIFF
--- a/wp-migrate-db-pro-tweaks.php
+++ b/wp-migrate-db-pro-tweaks.php
@@ -22,7 +22,6 @@ Author URI: http://deliciousbrains.com
 class WP_Migrate_DB_Pro_Tweaks {
 
 	function __construct() {
-		if ( !is_admin() ) return;
 		add_action( 'init', array( $this, 'init' ), 9 );
 	}
 


### PR DESCRIPTION
... WP Migrate DB Pro CLI addon.
